### PR TITLE
Register mccabe pytest marker

### DIFF
--- a/pytest_mccabe.py
+++ b/pytest_mccabe.py
@@ -26,7 +26,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     if config.option.mccabe:
-        config.addinivalue_line('markers', 'mccabe: Tests which run mccabe checks')
+        config.addinivalue_line('markers', 'mccabe: Tests which run mccabe')
 
 
 def pytest_sessionstart(session):

--- a/pytest_mccabe.py
+++ b/pytest_mccabe.py
@@ -24,6 +24,11 @@ def pytest_addoption(parser):
              "deactivate checking). example: *.py 10")
 
 
+def pytest_configure(config):
+    if config.option.mccabe:
+        config.addinivalue_line('markers', 'mccabe: Tests which run mccabe checks')
+
+
 def pytest_sessionstart(session):
     config = session.config
     if config.option.mccabe:


### PR DESCRIPTION
This is required for compatibility with pytest --strict mode when using
pytest>=3.1 as discussed in https://github.com/pytest-dev/pytest/issues/2455

Confirmed to fix the issue on my machine.